### PR TITLE
Use npx to run Yeoman

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Installing via Homebrew will also install the latest version of Node.js on your 
 ## Installation via NPM
 
 ```
-$ npm install -g yo
-$ npm install -g generator-swiftserver
 $ npm install -g kitura-cli
 ```
 

--- a/kitura-create.js
+++ b/kitura-create.js
@@ -1,30 +1,23 @@
 #!/usr/bin/env node
 
-const chalk = require('chalk');
 const program = require('commander');
 const spawn = require('child_process').spawn;
-const spawnSync = require('child_process').spawnSync;
 
 program
     .arguments('[modelname]')
     .parse(process.argv);
 
-// Run NPM to install the Yeoman generator
-var npm = spawnSync('npm', ['install', '-g', 'generator-swiftserver'], { stdio: 'inherit' });
-if (npm.error) {
-    console.error(chalk.red('Error: ') + 'NPM package installation failed');
-    process.exit(npm.status);
-}
-
-let options = ['swiftserver']
+let options = ['-p', 'yo@1', '-p', 'generator-swiftserver', '--', 'yo'];
 
 // If a parameter is passed, use this as a model name
 if (program.args[0]) {
-    options = ['swiftserver:model', program.args[0]];
+    options.push('swiftserver:model', program.args[0]);
+} else {
+    options.push('swiftserver');
 }
 
 // Run the generator
-let child = spawn('yo', options, { stdio: 'inherit' });
+let child = spawn('npx', options, { stdio: 'inherit' });
 child.on('error', (err) => {
     console.error(err);
 });

--- a/kitura-init.js
+++ b/kitura-init.js
@@ -1,21 +1,12 @@
 #!/usr/bin/env node
 
-const chalk = require('chalk');
 const program = require('commander');
 const spawn = require('child_process').spawn;
-const spawnSync = require('child_process').spawnSync;
 
 program
     .parse(process.argv);
 
-// Run NPM to install the Yeoman generator
-var npm = spawnSync('npm', ['install', '-g', 'generator-swiftserver'], { stdio: 'inherit' });
-if (npm.error) {
-    console.error(chalk.red('Error: ') + 'NPM package installation failed');
-    process.exit(npm.status);
-}
-
-let child = spawn('yo', ['swiftserver', '--init'], { stdio: 'inherit' });
+let child = spawn('npx', ['-p', 'yo@1', '-p', 'generator-swiftserver', '--', 'yo', 'swiftserver', '--init'], { stdio: 'inherit' });
 child.on('error', (err) => {
     console.error(err);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "ajv": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
-      "integrity": "sha1-tjcjTT4mdetfefxlIkKoU6SMtJ8=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ansi-styles": {
@@ -176,6 +176,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -209,7 +214,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.2.5",
+        "ajv": "5.3.0",
         "har-schema": "2.0.0"
       }
     },
@@ -226,7 +231,7 @@
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
         "hoek": "4.2.0",
-        "sntp": "2.0.2"
+        "sntp": "2.1.0"
       }
     },
     "hoek": {
@@ -270,23 +275,10 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -367,9 +359,9 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sntp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
         "hoek": "4.2.0"
       }


### PR DESCRIPTION
Currently, we run `npm i -g generator-swiftserver` every time a user invokes `kitura init` or `kitura create`. This ensures that the generator is installed into the user's NPM global package directory. 

We are unable to install the generator during Homebrew installation of the CLI because Homebrew installs global packages into Cellars which Yeoman can't find, and we can't trick Yeoman without breaking people who are using tools like `nvm`.

[NPX](http://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) is a relatively new addition to the Node.js ecosystem which simplifies the running of CLI tools from the registry (like Yeoman) and makes it unnecessary to install global packages at all.

This PR updates the Kitura CLI so it invokes Yeoman via `npx`.  A consequence of this is we will be able to simplify the Homebrew installation of the CLI so it does not have to install Yeoman either.

My belief is that this will sidestep a whole bunch of rare NPM issues that users have reported.