### PR TITLE
Update kitura init to clone instead of running generator

### DIFF
--- a/kitura-init.js
+++ b/kitura-init.js
@@ -2,8 +2,12 @@
 
 const chalk = require('chalk');
 const spawnSync = require('child_process').spawnSync;
-var os = require('os');
-var fs = require('fs');
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const initURL = 'https://github.com/IBM-Swift/generator-swiftserver-projects'
+const initBranch = 'init'
 
 let args = process.argv.slice(2);
 
@@ -14,133 +18,127 @@ if (args.length > 0) {
     }
 }
 
-let path = require("path");
 let currentDirPath = path.resolve("./");
 let currentDir = path.basename(currentDirPath);
 // Replace spaces with hyphens so Xcode project will build.
-let projName = currentDir.replace(/ /g,"-")
+let projName = currentDir.replace(/ /g,"-");
 
 if (projName.charAt(0) === '.') {
-     console.error('Application name cannot start with .: %s')
+    console.error(chalk.red('Application name cannot start with .: %s'));
    }
-   if (projName.toLowerCase() === 'node_modules') {
-    console.error('Application name cannot be {node_modules}')
+if (projName.toLowerCase() === 'node_modules') {
+    console.error(chalk.red('Application name cannot be {node_modules}'));
    }
-   if (projName.toLowerCase() === 'favicon.ico') {
-     console.error('Application name cannot be {favicon.ico}')
+if (projName.toLowerCase() === 'favicon.ico') {
+    console.error(chalk.red('Application name cannot be {favicon.ico}'));
 }
 
 // Make sure directory is empty.
-checkEmptyDir()
+checkCurrentDirIsEmpty();
 
 // Clone repo contents into current directory.
-cloneProject()
+cloneProject(initURL, initBranch);
 
 // Rename project to match current directory
-renameProject()
+renameProject();
 
 // If '--skip-build' not specified, then build project.
 if (!(args.includes('--skip-build'))) {
-    buildProject()
+    buildProject();
 }
 
-function checkEmptyDir() {
+function checkCurrentDirIsEmpty() {
   try {
-    var data = fs.readdirSync('.')
-    if (data.length !== 0) {
-      console.error(chalk.red('Current directory is not empty.'));
-      console.error(chalk.red('Please repeat the command in an empty directory.'));
-      process.exit()
-    }
-
-  } catch(err) {
-    console.error(err)
-    process.exit()
+      var data = fs.readdirSync('.');
+      if (data.length !== 0) {
+            console.error(chalk.red('Current directory is not empty.'));
+            console.error(chalk.red('Please repeat the command in an empty directory.'));
+            process.exit();
+      }
+  } catch (err) {
+      process.exit();
   }
 }
 
-function cloneProject() {
-  console.log('Creating project...')
-  let clone = spawnSync('git', ['clone', '-b', 'init', 'https://github.com/IBM-Swift/generator-swiftserver-projects', '.'])
+function cloneProject(url, branch) {
+    console.log('Creating project...');
+    let clone = spawnSync('git', ['clone', '-b', branch, url, '.']);
 
-  if (clone.status !== 0) {
-    console.error(chalk.red('Error: ') + 'failed to run git clone.');
-    console.error('Please check that you have git installed.');
-    console.error('Head to https://git-scm.com/downloads for more info.');
-    process.exit(clone.status);
-  }
-  else {
-    console.log(chalk.green('Project created successfully.'));
-    if ((args.includes('--skip-build'))) {
-      console.log('Next steps:')
-      console.log('')
-      console.log('Generate your Xcode project:')
-      console.log(chalk.grey('   $ swift package generate-xcodeproj'))
-      console.log('')
-      console.log('Or, build your project from the terminal:')
-      console.log(chalk.grey('   $ swift build -Xlinker -lc++'))
-    }
+    if (clone.status !== 0) {
+        console.error(chalk.red('Error: ') + 'failed to run git clone.');
+        console.error('Please check that you have git installed.');
+        console.error('Head to https://git-scm.com/downloads for more info.');
+        process.exit(clone.status);
+    } else {
+        console.log(chalk.green('Project created successfully.'));
+        if ((args.includes('--skip-build'))) {
+            console.log('Next steps:');
+            console.log('');
+            console.log('Generate your Xcode project:');
+            console.log(chalk.grey('   $ swift package generate-xcodeproj'));
+            console.log('');
+            console.log('Or, build your project from the terminal:');
+            console.log(chalk.grey('   $ swift build'));
+       }
   }
 
-  // Remove git tracking
-  let git = spawnSync('rm', ['-rf', '.git'])
+  // Remove git remote
+  let git = spawnSync('rm', ['-rf', '.git']);
   if (git.status !== 0) {
-    console.error(chalk.red('Error: ') + 'failed to remove git tracking.');
-    process.exit(git.status);
+      console.error(chalk.red('Error: ') + 'failed to remove .git directory.');
+      process.exit(git.status);
   }
 }
 
 function renameProject() {
-  let projNameClean = projName.replace(/^[^a-zA-Z]*/, '')
+    // Clean name can only contain alphanumberic characters
+    let projNameClean = projName.replace(/^[^a-zA-Z]*/, '')
                                   .replace(/[^a-zA-Z0-9]/g, '');
-  let oldProjName = "generator-swiftserver-projects"
-  let oldProjNameClean = "generatorswiftserverprojects"
+    let oldProjName = "generator-swiftserver-projects";
+    let oldProjNameClean = "generatorswiftserverprojects";
 
-  // Rename directories (charts can't contain special characters).
-  try {
-    fs.renameSync("./chart/" + oldProjNameClean, "./chart/" + projNameClean);
-    fs.renameSync("./Sources/" + oldProjName, "./Sources/" + projName);
-  } catch (err) {
-    console.error(err)
-    process.exit()
-  }
-  // Rename instances of project name (charts can't contain special characters)
-  var renameClean = spawnSync('find', ['.', '-exec', 'sed', '-i', '', 's/'+oldProjNameClean+'/'+projNameClean+'/g', '{}', ';'])
-  if (renameClean.status !== 0){
-    console.error(chalk.red('Error: ') + 'could not rename project.');
-    console.log(renameClean.stderr.toString())
-    process.exit()
-  }
-  var rename = spawnSync('find', ['.', '-exec', 'sed', '-i', '', 's/'+oldProjName+'/'+projName+'/g', '{}', ';'])
-  if (rename.status !== 0){
-    console.error(chalk.red('Error: ') + 'could not rename project.');
-    console.log(rename.stderr.toString())
-    process.exit()
-  }
+    // Rename directories (charts can't contain special characters).
+    try {
+        fs.renameSync("./chart/" + oldProjNameClean, "./chart/" + projNameClean);
+        fs.renameSync("./Sources/" + oldProjName, "./Sources/" + projName);
+    } catch (err) {
+        console.error(chalk.red('Error: ') + 'could not rename directories.');
+        console.error(err.message);
+        process.exit(err.errno);
+    }
+    // Rename instances of project name (charts can't contain special characters)
+    var renameClean = spawnSync('find', ['.', '-exec', 'sed', '-i', '', 's/'+oldProjNameClean+'/'+projNameClean+'/g', '{}', ';'])
+    if (renameClean.status !== 0) {
+        console.error(chalk.red('Error: ') + 'could not rename project.');
+        console.error(renameClean.stderr.toString());
+        process.exit(renameClean.status);
+    }
+    var rename = spawnSync('find', ['.', '-exec', 'sed', '-i', '', 's/'+oldProjName+'/'+projName+'/g', '{}', ';'])
+    if (rename.status !== 0) {
+        console.error(chalk.red('Error: ') + 'could not rename project.');
+        console.error(rename.stderr.toString());
+        process.exit(rename.status);
+    }
 }
 
 function buildProject() {
-  console.log('Running `swift build -Xlinker -lc++` to build project...')
-    var opts = []
-          if (os.platform() === 'darwin') {
-            opts = ['-Xlinker', '-lc++']
-          }
+    console.log('Running `swift build` to build project...');
 
-    var build = spawnSync('swift', ['build'].concat(opts))
+    var build = spawnSync('swift', ['build'])
     if (build.status !== 0) {
-      console.error(chalk.red('Failed to complete build.'));
-      console.log(build.stderr.toString())
-      process.exit(build.status);
+        console.error(chalk.red('Failed to complete build.'));
+        console.log(build.stderr.toString());
+        process.exit(build.status);
     }
     else {
-      console.log(chalk.green('Project built successfully.'));
-      console.log('Next steps:')
-      console.log('')
-      console.log('Generate your Xcode project:')
-      console.log(chalk.grey('   $ swift package generate-xcodeproj'))
-      console.log('')
-      console.log('Or, run your app from the terminal:')
-      console.log(chalk.grey('   $ .build/debug/' + projName))
+        console.log(chalk.green('Project built successfully.'));
+        console.log('Next steps:');
+        console.log('');
+        console.log('Generate your Xcode project:');
+        console.log(chalk.grey('   $ swift package generate-xcodeproj'));
+        console.log('');
+        console.log('Or, run your app from the terminal:');
+        console.log(chalk.grey('   $ .build/debug/' + projName));
     }
   }
 

--- a/kitura-init.js
+++ b/kitura-init.js
@@ -61,7 +61,7 @@ function checkEmptyDir() {
 
 function cloneProject() {
   console.log('Creating project...')
-  let clone = spawnSync('git', ['clone', 'https://github.com/IBM-Swift/generator-swiftserver-projects', '.'])
+  let clone = spawnSync('git', ['clone', '-b', 'init', 'https://github.com/IBM-Swift/generator-swiftserver-projects', '.'])
 
   if (clone.status !== 0) {
     console.error(chalk.red('Error: ') + 'failed to run git clone.');

--- a/kitura-init.js
+++ b/kitura-init.js
@@ -21,12 +21,12 @@ if (args.length > 0) {
 let currentDirPath = path.resolve("./");
 let currentDir = path.basename(currentDirPath);
 // Replace spaces with hyphens so Xcode project will build.
-let projName = currentDir.replace(/ /g,"-");
+let projName = currentDir.replace(/ /g, "-");
 
 if (projName.charAt(0) === '.') {
     console.error(chalk.red('Application name cannot start with .: %s'));
     process.exit(1)
-   }
+}
 
 
 // Make sure directory is empty.
@@ -44,18 +44,18 @@ if (!(args.includes('--skip-build'))) {
 }
 
 function checkCurrentDirIsEmpty() {
-  try {
-      var data = fs.readdirSync('.');
-      if (data.length !== 0) {
+    try {
+        var data = fs.readdirSync('.');
+        if (data.length !== 0) {
             console.error(chalk.red('Error:') + 'Current directory is not empty.');
             console.error(chalk.red('Please repeat the command in an empty directory.'));
             process.exit(1);
-      }
-  } catch (err) {
-      console.error(chalk.red('Error: ') + 'could not create project.');
-      console.error(err.message);
-      process.exit(err.errno);
-  }
+        }
+    } catch (err) {
+        console.error(chalk.red('Error: ') + 'could not create project.');
+        console.error(err.message);
+        process.exit(err.errno);
+    }
 }
 
 function cloneProject(url, branch) {
@@ -77,21 +77,21 @@ function cloneProject(url, branch) {
             console.log('');
             console.log('Or, build your project from the terminal:');
             console.log(chalk.grey('   $ swift build'));
-       }
-  }
+        }
+    }
 
-  // Remove git remote
-  let git = spawnSync('rm', ['-rf', '.git']);
-  if (git.status !== 0) {
-      console.error(chalk.red('Error: ') + 'failed to remove .git directory.');
-      process.exit(git.status);
-  }
+    // Remove git remote
+    let git = spawnSync('rm', ['-rf', '.git']);
+    if (git.status !== 0) {
+        console.error(chalk.red('Error: ') + 'failed to remove .git directory.');
+        process.exit(git.status);
+    }
 }
 
 function renameProject() {
     // Clean name can only contain alphanumeric characters
     let projNameClean = projName.replace(/^[^a-zA-Z]*/, '')
-                                  .replace(/[^a-zA-Z0-9]/g, '');
+        .replace(/[^a-zA-Z0-9]/g, '');
     let oldProjName = "generator-swiftserver-projects";
     let oldProjNameClean = "generatorswiftserverprojects";
 
@@ -105,13 +105,13 @@ function renameProject() {
         process.exit(err.errno);
     }
     // Rename instances of project name (charts can't contain special characters)
-    var renameClean = spawnSync('find', ['.', '-exec', 'sed', '-i', '', 's/'+oldProjNameClean+'/'+projNameClean+'/g', '{}', ';'])
+    var renameClean = spawnSync('find', ['.', '-exec', 'sed', '-i', '', 's/' + oldProjNameClean + '/' + projNameClean + '/g', '{}', ';'])
     if (renameClean.status !== 0) {
         console.error(chalk.red('Error: ') + 'could not rename project.');
         console.error(renameClean.stderr.toString());
         process.exit(renameClean.status);
     }
-    var rename = spawnSync('find', ['.', '-exec', 'sed', '-i', '', 's/'+oldProjName+'/'+projName+'/g', '{}', ';'])
+    var rename = spawnSync('find', ['.', '-exec', 'sed', '-i', '', 's/' + oldProjName + '/' + projName + '/g', '{}', ';'])
     if (rename.status !== 0) {
         console.error(chalk.red('Error: ') + 'could not rename project.');
         console.error(rename.stderr.toString());
@@ -127,8 +127,7 @@ function buildProject() {
         console.error(chalk.red('Failed to complete build.'));
         console.log(build.stderr.toString());
         process.exit(build.status);
-    }
-    else {
+    } else {
         console.log(chalk.green('Project built successfully.'));
         console.log('Next steps:');
         console.log('');
@@ -138,7 +137,7 @@ function buildProject() {
         console.log('Or, run your app from the terminal:');
         console.log(chalk.grey('   $ .build/debug/' + projName));
     }
-  }
+}
 
 
 

--- a/kitura-init.js
+++ b/kitura-init.js
@@ -1,32 +1,150 @@
 #!/usr/bin/env node
 
 const chalk = require('chalk');
-const spawn = require('child_process').spawn;
+const spawnSync = require('child_process').spawnSync;
+var os = require('os');
+var fs = require('fs');
 
 let args = process.argv.slice(2);
-
-let options = ['-p', 'yo@1', '-p', 'generator-swiftserver', '--', 'yo', 'swiftserver'];
 
 if (args.length > 0) {
     if (args.indexOf('--help') > -1) {
         printHelp();
         process.exit(0);
     }
-
-    // Add on the arguments
-    options.push(args);
 }
 
-options.push('--init');
+let path = require("path");
+let currentDirPath = path.resolve("./");
+let currentDir = path.basename(currentDirPath);
+// Replace spaces with hyphens so Xcode project will build.
+let projName = currentDir.replace(/ /g,"-")
 
-let child = spawn('npx', options, { stdio: 'inherit' });
-child.on('error', (err) => {
-    console.error(chalk.red('Error: ') + 'failed to run npx.');
-    console.error('Please check `node -v` is >= v8.2.0 and `npm -v` is >= 5.2.0.');
-});
-child.on('close', (code) => {
-    process.exit(code);
-});
+if (projName.charAt(0) === '.') {
+     console.error('Application name cannot start with .: %s')
+   }
+   if (projName.toLowerCase() === 'node_modules') {
+    console.error('Application name cannot be {node_modules}')
+   }
+   if (projName.toLowerCase() === 'favicon.ico') {
+     console.error('Application name cannot be {favicon.ico}')
+}
+
+// Make sure directory is empty.
+checkEmptyDir()
+
+// Clone repo contents into current directory.
+cloneProject()
+
+// Rename project to match current directory
+renameProject()
+
+// If '--skip-build' not specified, then build project.
+if (!(args.includes('--skip-build'))) {
+    buildProject()
+}
+
+function checkEmptyDir() {
+  try {
+    var data = fs.readdirSync('.')
+    if (data.length !== 0) {
+      console.error(chalk.red('Current directory is not empty.'));
+      console.error(chalk.red('Please repeat the command in an empty directory.'));
+      process.exit()
+    }
+
+  } catch(err) {
+    console.error(err)
+    process.exit()
+  }
+}
+
+function cloneProject() {
+  console.log('Creating project...')
+  let clone = spawnSync('git', ['clone', 'https://github.com/IBM-Swift/generator-swiftserver-projects', '.'])
+
+  if (clone.status !== 0) {
+    console.error(chalk.red('Error: ') + 'failed to run git clone.');
+    console.error('Please check that you have git installed.');
+    console.error('Head to https://git-scm.com/downloads for more info.');
+    process.exit(clone.status);
+  }
+  else {
+    console.log(chalk.green('Project created successfully.'));
+    if ((args.includes('--skip-build'))) {
+      console.log('Next steps:')
+      console.log('')
+      console.log('Generate your Xcode project:')
+      console.log(chalk.grey('   $ swift package generate-xcodeproj'))
+      console.log('')
+      console.log('Or, build your project from the terminal:')
+      console.log(chalk.grey('   $ swift build -Xlinker -lc++'))
+    }
+  }
+
+  // Remove git tracking
+  let git = spawnSync('rm', ['-rf', '.git'])
+  if (git.status !== 0) {
+    console.error(chalk.red('Error: ') + 'failed to remove git tracking.');
+    process.exit(git.status);
+  }
+}
+
+function renameProject() {
+  let projNameClean = projName.replace(/^[^a-zA-Z]*/, '')
+                                  .replace(/[^a-zA-Z0-9]/g, '');
+  let oldProjName = "generator-swiftserver-projects"
+  let oldProjNameClean = "generatorswiftserverprojects"
+
+  // Rename directories (charts can't contain special characters).
+  try {
+    fs.renameSync("./chart/" + oldProjNameClean, "./chart/" + projNameClean);
+    fs.renameSync("./Sources/" + oldProjName, "./Sources/" + projName);
+  } catch (err) {
+    console.error(err)
+    process.exit()
+  }
+  // Rename instances of project name (charts can't contain special characters)
+  var renameClean = spawnSync('find', ['.', '-exec', 'sed', '-i', '', 's/'+oldProjNameClean+'/'+projNameClean+'/g', '{}', ';'])
+  if (renameClean.status !== 0){
+    console.error(chalk.red('Error: ') + 'could not rename project.');
+    console.log(renameClean.stderr.toString())
+    process.exit()
+  }
+  var rename = spawnSync('find', ['.', '-exec', 'sed', '-i', '', 's/'+oldProjName+'/'+projName+'/g', '{}', ';'])
+  if (rename.status !== 0){
+    console.error(chalk.red('Error: ') + 'could not rename project.');
+    console.log(rename.stderr.toString())
+    process.exit()
+  }
+}
+
+function buildProject() {
+  console.log('Running `swift build -Xlinker -lc++` to build project...')
+    var opts = []
+          if (os.platform() === 'darwin') {
+            opts = ['-Xlinker', '-lc++']
+          }
+
+    var build = spawnSync('swift', ['build'].concat(opts))
+    if (build.status !== 0) {
+      console.error(chalk.red('Failed to complete build.'));
+      console.log(build.stderr.toString())
+      process.exit(build.status);
+    }
+    else {
+      console.log(chalk.green('Project built successfully.'));
+      console.log('Next steps:')
+      console.log('')
+      console.log('Generate your Xcode project:')
+      console.log(chalk.grey('   $ swift package generate-xcodeproj'))
+      console.log('')
+      console.log('Or, run your app from the terminal:')
+      console.log(chalk.grey('   $ .build/debug/' + projName))
+    }
+  }
+
+
 
 function printHelp() {
     console.log("");

--- a/kitura-init.js
+++ b/kitura-init.js
@@ -25,13 +25,9 @@ let projName = currentDir.replace(/ /g,"-");
 
 if (projName.charAt(0) === '.') {
     console.error(chalk.red('Application name cannot start with .: %s'));
+    process.exit(1)
    }
-if (projName.toLowerCase() === 'node_modules') {
-    console.error(chalk.red('Application name cannot be {node_modules}'));
-   }
-if (projName.toLowerCase() === 'favicon.ico') {
-    console.error(chalk.red('Application name cannot be {favicon.ico}'));
-}
+
 
 // Make sure directory is empty.
 checkCurrentDirIsEmpty();
@@ -51,12 +47,14 @@ function checkCurrentDirIsEmpty() {
   try {
       var data = fs.readdirSync('.');
       if (data.length !== 0) {
-            console.error(chalk.red('Current directory is not empty.'));
+            console.error(chalk.red('Error:') + 'Current directory is not empty.');
             console.error(chalk.red('Please repeat the command in an empty directory.'));
-            process.exit();
+            process.exit(1);
       }
   } catch (err) {
-      process.exit();
+      console.error(chalk.red('Error: ') + 'could not create project.');
+      console.error(err.message);
+      process.exit(err.errno);
   }
 }
 
@@ -66,8 +64,8 @@ function cloneProject(url, branch) {
 
     if (clone.status !== 0) {
         console.error(chalk.red('Error: ') + 'failed to run git clone.');
-        console.error('Please check that you have git installed.');
-        console.error('Head to https://git-scm.com/downloads for more info.');
+        console.error('Please check your network connection and that you have git installed.');
+        console.error('Head to https://git-scm.com/downloads for instructions on installing git.');
         process.exit(clone.status);
     } else {
         console.log(chalk.green('Project created successfully.'));
@@ -91,7 +89,7 @@ function cloneProject(url, branch) {
 }
 
 function renameProject() {
-    // Clean name can only contain alphanumberic characters
+    // Clean name can only contain alphanumeric characters
     let projNameClean = projName.replace(/^[^a-zA-Z]*/, '')
                                   .replace(/[^a-zA-Z0-9]/g, '');
     let oldProjName = "generator-swiftserver-projects";


### PR DESCRIPTION
Will now clone from repo instead of running generator, which should hopefully speed up creating a project. 
Function stays the same, but output from running command will change and will look like the following (with success messages highlighted in green):
``` bash
awishart$ kitura init
Creating project...
Project created successfully.
Running `swift build -Xlinker -lc++` to build project...
Project built successfully.
Next steps:

Generate your Xcode project:
   $ swift package generate-xcodeproj

Or, run your app from the terminal:
   $ .build/debug/init-init-init
```