### PR TITLE
Add 'sdk' command to generate client SDKs from OpenAPI spec

### DIFF
--- a/kitura-sdk.js
+++ b/kitura-sdk.js
@@ -36,11 +36,11 @@ function printHelp() {
     console.log("  Targets:");
     console.log("    --ios             Create an iOS SDK");
     console.log("    --android         Create an Android SDK");
-    console.log("    --js             Create a JavaScript SDK");
+    console.log("    --js              Create a JavaScript SDK");
     console.log("");
     console.log("  Options:");
     console.log("    -l <location>     Use a locally hosted specification, eg. http://localhost:8080/openapi");
-    console.log("    -f <location>     Use a loal file for the specification");
+    console.log("    -f <location>     Use a local file for the specification");
     console.log("    --help            print this help");
     console.log("");
     console.log("  Sample Usage:");

--- a/kitura-sdk.js
+++ b/kitura-sdk.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+const chalk = require('chalk');
+const spawn = require('child_process').spawn;
+
+// Remove the node executable and script name
+let args = process.argv.slice(2);
+
+let options = ['sdk', 'generate'];
+
+if (args.length > 0) {
+    if (args.indexOf('--help') > -1) {
+        printHelp();
+        process.exit(0);
+    }
+
+    // Add on the rest of the arguments
+    options = options.concat(args);
+}
+
+let child = spawn('bx', options, { stdio: 'inherit' });
+child.on('error', (err) => {
+    console.error(chalk.red('Error: ') + 'failed to run IBM Cloud Developer Tools');
+    console.error('Run `kitura idt` to install');
+});
+child.on('close', (code) => {
+    process.exit(code);
+});
+
+function printHelp() {
+    console.log("");
+    console.log("  Usage: kitura sdk [target] [options]");
+    console.log("");
+    console.log("  Create a client SDK from an OpenAPI/Swagger specification.");
+    console.log("");
+    console.log("  Targets:");
+    console.log("    --ios             Create an iOS SDK");
+    console.log("    --android         Create an Android SDK");
+    console.log("    --js             Create a JavaScript SDK");
+    console.log("");
+    console.log("  Options:");
+    console.log("    -l <location>     Use a locally hosted specification, eg. http://localhost:8080/openapi");
+    console.log("    -f <location>     Use a loal file for the specification");
+    console.log("    --help            print this help");
+    console.log("");
+    console.log("  Sample Usage:");
+    console.log("    kitura sdk --android -l http://localhost:8080/openapi");
+}

--- a/kitura.js
+++ b/kitura.js
@@ -12,4 +12,5 @@ program
     .command('init', 'scaffold a bare-bones Kitura project')
     .command('kit', 'print Cocoapods boilerplate for KituraKit')
     .command('run', 'run the project in a local container')
+    .command('sdk', 'generate a client SDK from an OpenAPI/Swagger spec')
     .parse(process.argv);


### PR DESCRIPTION
Add support for calling 'bx dev' to generate a client SDK from an OpenAPI spec now that Kitura can auto-generate the spec.

I've added docs describing how to create from local file or localhost url, and how to generate for Android, iOS and JavaScript. I believe that there are more SDK types that we can add in the future.