### PR TITLE
Updates output for Kitura Kit

### DIFF
--- a/kitura-kit.js
+++ b/kitura-kit.js
@@ -8,5 +8,5 @@ program
 console.log('Add the following lines to your Podfile to install KituraKit into your iOS app using CocoaPods:');
 console.log('');
 console.log('# Pod for KituraKit');
-console.log('pod \'KituraKit\', :git => \'https://github.com/IBM-Swift/KituraKit.git\', :branch => \'pod\'');
+console.log('pod \'KituraKit\'');
 


### PR DESCRIPTION
Legacy support for KituraKit using cocoapods referred to a `pod` branch - this eliminates that and refers to the master branch for the dependency in the console output.