### PR TITLE
Update `bx` to `ibmcloud`

### DIFF
--- a/kitura-build.js
+++ b/kitura-build.js
@@ -7,7 +7,7 @@ const spawn = require('child_process').spawn;
 program
     .parse(process.argv);
 
-let child = spawn('bx', ['dev', 'build'], { stdio: 'inherit' });
+let child = spawn('ibmcloud', ['dev', 'build'], { stdio: 'inherit' });
 child.on('error', (err) => {
     console.error(chalk.red('Error: ') + 'failed to run IBM Cloud Developer Tools');
     console.error('Run `kitura idt` to install');

--- a/kitura-run.js
+++ b/kitura-run.js
@@ -7,7 +7,7 @@ const spawn = require('child_process').spawn;
 program
     .parse(process.argv);
 
-let child = spawn('bx', ['dev', 'run'], { stdio: 'inherit' });
+let child = spawn('ibmcloud', ['dev', 'run'], { stdio: 'inherit' });
 child.on('error', (err) => {
     console.error(chalk.red('Error: ') + 'failed to run IBM Cloud Developer Tools');
     console.error('Run `kitura idt` to install');

--- a/kitura-sdk.js
+++ b/kitura-sdk.js
@@ -18,7 +18,7 @@ if (args.length > 0) {
     options = options.concat(args);
 }
 
-let child = spawn('bx', options, { stdio: 'inherit' });
+let child = spawn('ibmcloud', options, { stdio: 'inherit' });
 child.on('error', (err) => {
     console.error(chalk.red('Error: ') + 'failed to run IBM Cloud Developer Tools');
     console.error('Run `kitura idt` to install');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kitura-cli",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Kitura command-line interface",
   "bin": {
     "kitura": "kitura.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kitura-cli",
-  "version": "0.0.15",
+  "version": "0.0.14",
   "description": "Kitura command-line interface",
   "bin": {
     "kitura": "kitura.js",


### PR DESCRIPTION
The `ibmcloud` cli is mature enough to be considered trusty at this point. @lordandrei had an issue with `bx` running on their machine, because it is already an alias for something called Bitcoin Explorer.