### PR TITLE
update IBM-Swift refs to Kitura

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    repo: IBM-Swift/kitura-cli
+    repo: Kitura/kitura-cli

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Kitura command-line interface
 
-This Go package provides a `kitura` command-line interface, to simplify the process of creating [Kitura](https://github.com/IBM-Swift/Kitura) applications.
+This Go package provides a `kitura` command-line interface, to simplify the process of creating [Kitura](https://github.com/Kitura/Kitura) applications.
 
 ## Installation on macOS (via Homebrew)
 
 Kitura's CLI may be installed using [Homebrew](https://brew.sh):
 ```
-$ brew tap ibm-swift/kitura
+$ brew tap kitura/kitura
 $ brew install kitura
 ```
 
@@ -14,7 +14,7 @@ $ brew install kitura
 
 You can install (either on Mac or Linux) with this one-liner:
 ```
-$ curl -fsSL https://github.com/IBM-Swift/kitura-cli/releases/latest/download/install.sh | sudo bash
+$ curl -fsSL https://github.com/Kitura/kitura-cli/releases/latest/download/install.sh | sudo bash
 ```
 The `kitura` binary will be placed in your `/usr/local/bin` directory.
 
@@ -24,14 +24,14 @@ If you'd prefer not to use a script, the binary can be installed manually by dow
 
 On Mac:
 ```
-$ curl -LO https://github.com/IBM-Swift/kitura-cli/releases/download/<release>/kitura-cli_<release>_darwin.tar.gz
+$ curl -LO https://github.com/Kitura/kitura-cli/releases/download/<release>/kitura-cli_<release>_darwin.tar.gz
 $ tar -xzf kitura-cli_<release>_darwin.tar.gz
 $ sudo mv darwin-amd64/kitura /usr/local/bin/
 ```
 
 On Linux:
 ```
-curl -LO https://github.com/IBM-Swift/kitura-cli/releases/download/<release>/kitura-cli_<release>_amd64.deb
+curl -LO https://github.com/Kitura/kitura-cli/releases/download/<release>/kitura-cli_<release>_amd64.deb
 sudo dpkg -i kitura-cli_<release>_amd64.deb
 ```
 

--- a/Release-Process.md
+++ b/Release-Process.md
@@ -8,7 +8,7 @@ The following instructions are for releasing a new version of kitura-cli:
 
 ### Updating homebrew
 
-- Clone https://github.com/IBM-Swift/homebrew-kitura and create a new branch.
+- Clone https://github.com/Kitura/homebrew-kitura and create a new branch.
 - Replace the `kitura.rb` file with the one that is attached to the release.
 - Push your changes, then raise and merge the PR.
 - Update your version of the cli by running `brew upgrade kitura` and do a final check to make sure your updates are running as expected.

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -165,12 +165,12 @@ func validateProjectName(name string) error {
 }
 
 /*
-	Uses go-git to clone a specified branch of the IBM-Swift/generator-swiftserver-projects repo to a specified directory.
+	Uses go-git to clone a specified branch of the Kitura/generator-swiftserver-projects repo to a specified directory.
 */
 func cloneProjectFor(branch, directory string) error {
 	log.Printf("Cloning kitura project into %v\n", directory)
 	_, err := git.PlainClone(directory, false, &git.CloneOptions{
-		URL:           "https://github.com/IBM-Swift/generator-swiftserver-projects",
+		URL:           "https://github.com/Kitura/generator-swiftserver-projects",
 		Progress:      os.Stdout,
 		ReferenceName: plumbing.ReferenceName(fmt.Sprintf("refs/heads/%v", branch)),
 		SingleBranch:  true,

--- a/install.sh.ver
+++ b/install.sh.ver
@@ -3,13 +3,13 @@ RELEASE=@@RELEASE@@
 case `uname` in
   Darwin)
     PKG_NAME=kitura-cli_${RELEASE}_darwin.tar.gz
-    PKG_URL=https://github.com/IBM-Swift/kitura-cli/releases/download/${RELEASE}/${PKG_NAME}
+    PKG_URL=https://github.com/Kitura/kitura-cli/releases/download/${RELEASE}/${PKG_NAME}
 
     curl -sSLO $PKG_URL && tar -xzf $PKG_NAME && mv darwin-amd64/kitura /usr/local/bin/ && rmdir darwin-amd64 && rm $PKG_NAME && echo kitura-cli ${RELEASE} successfully installed.
     ;;
   Linux)
     PKG_NAME=kitura-cli_${RELEASE}_amd64.deb
-    PKG_URL=https://github.com/IBM-Swift/kitura-cli/releases/download/${RELEASE}/${PKG_NAME}
+    PKG_URL=https://github.com/Kitura/kitura-cli/releases/download/${RELEASE}/${PKG_NAME}
 
     curl -sSLO $PKG_URL && dpkg -i $PKG_NAME && rm $PKG_NAME && echo kitura-cli ${RELEASE} successfully installed.
     ;;

--- a/kitura.rb.ver
+++ b/kitura.rb.ver
@@ -1,7 +1,7 @@
 class Kitura < Formula
   desc "Kitura command-line interface"
-  homepage "https://github.com/IBM-Swift/kitura-cli#readme"
-  url "https://github.com/IBM-Swift/kitura-cli/releases/download/@@RELEASE@@/kitura-cli_@@RELEASE@@_darwin.tar.gz"
+  homepage "https://github.com/Kitura/kitura-cli#readme"
+  url "https://github.com/Kitura/kitura-cli/releases/download/@@RELEASE@@/kitura-cli_@@RELEASE@@_darwin.tar.gz"
   version "@@RELEASE@@"
   sha256 "@@SHA256@@"
 


### PR DESCRIPTION
Updated all IBM-Swift refs to Kitura

Note: There are still an IBM ref in the debian control file. This is in the maintainers email address.
`Maintainer: Swift-at-IBM <swiftdevops@us.ibm.com>`
We will need to decide on an email address to use for this.
